### PR TITLE
Create AI Forward consulting landing page

### DIFF
--- a/src/components/ActionLink.astro
+++ b/src/components/ActionLink.astro
@@ -11,11 +11,11 @@ const { label, ariaLabel, url, class: className, 'data-sb-field-path': fieldPath
 
 {
     url ? (
-        <a class:list={['text-neutral', className]} href={url} aria-label={ariaLabel} data-sb-field-path={fieldPath}>
+        <a class:list={['text-slate-700 transition hover:text-primary', className]} href={url} aria-label={ariaLabel} data-sb-field-path={fieldPath}>
             <span data-sb-field-path={fieldPath ? '.label' : undefined}>{label}</span>
         </a>
     ) : (
-        <button class:list={['text-neutral', className]} aria-label={ariaLabel} data-sb-field-path={fieldPath}>
+        <button class:list={['text-slate-700 transition hover:text-primary', className]} aria-label={ariaLabel} data-sb-field-path={fieldPath}>
             <span data-sb-field-path={fieldPath ? '.label' : undefined}>{label}</span>
         </button>
     )

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,12 +7,69 @@ interface Props extends Footer {
 }
 
 const { text, 'data-sb-field-path': fieldPath } = Astro.props;
+const hasCustomFooter = Boolean(text);
 ---
 
-{
-    text && (
-        <footer class="px-4 py-16 sm:px-5 sm:py-24" data-sb-field-path={fieldPath}>
-            <div class="mx-auto text-center max-w-7xl" data-sb-field-path=".text" set:html={marked.parse(text)} />
-        </footer>
-    )
-}
+<footer class="bg-slate-950 text-slate-100" data-sb-field-path={fieldPath}>
+    <div class="mx-auto max-w-7xl px-4 py-20 sm:px-6">
+        <div class="grid gap-12 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] lg:gap-16">
+            <div>
+                <a class="flex items-center gap-2 text-2xl font-semibold tracking-tight text-white" href="/">
+                    <span class="text-primary">⚡</span>
+                    <span>AI Forward</span>
+                </a>
+                <p class="mt-6 max-w-xl text-base text-slate-300">
+                    Strategic AI consulting for executive leaders who demand results. We partner with leadership teams to
+                    transform bold ideas into measurable impact.
+                </p>
+                <a
+                    class="btn btn-primary mt-8 inline-flex items-center rounded-full px-6 py-3 text-sm font-semibold tracking-wide shadow-lg shadow-primary/20"
+                    href="#consultation"
+                >
+                    Schedule Strategic Call
+                </a>
+                {hasCustomFooter && (
+                    <div class="markdown mt-8 max-w-2xl text-sm text-slate-400" data-sb-field-path=".text" set:html={marked.parse(text ?? '')} />
+                )}
+            </div>
+            <div>
+                <h3 class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Resources</h3>
+                <ul class="mt-5 space-y-3 text-sm text-slate-300">
+                    <li>
+                        <a class="transition hover:text-primary" href="#challenge">The Strategic Challenge</a>
+                    </li>
+                    <li>
+                        <a class="transition hover:text-primary" href="#approach">Our Proven Framework</a>
+                    </li>
+                    <li>
+                        <a class="transition hover:text-primary" href="#solutions">Strategic Solutions</a>
+                    </li>
+                    <li>
+                        <a class="transition hover:text-primary" href="#leadership">Leadership Team</a>
+                    </li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Contact</h3>
+                <ul class="mt-5 space-y-3 text-sm text-slate-300">
+                    <li>
+                        <a class="transition hover:text-primary" href="tel:+14379614590">(437) 961-4590</a>
+                    </li>
+                    <li>
+                        <a class="transition hover:text-primary" href="mailto:contact@aiforward.ca">contact@aiforward.ca</a>
+                    </li>
+                    <li>
+                        <span>Toronto • Serving global leadership teams</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="mt-16 flex flex-col gap-4 border-t border-white/10 pt-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
+            <p>© 2024 AI Forward. All Rights Reserved.</p>
+            <div class="flex flex-wrap gap-6">
+                <a class="transition hover:text-primary" href="#">Privacy Policy</a>
+                <a class="transition hover:text-primary" href="#">Terms of Service</a>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,30 +8,36 @@ interface Props extends Header {
 }
 
 const { title, logo, navLinks, 'data-sb-field-path': fieldPath } = Astro.props;
+const wordmark = (title || 'AI Forward').replace('⚡', '').trim();
 ---
 
-<nav class="p-4 sm:p-5" data-sb-field-path={fieldPath}>
-    <div class="flex items-center justify-between w-full gap-6 mx-auto max-w-7xl">
+<nav class="sticky top-0 z-50 border-b border-slate-200/70 bg-white/80 backdrop-blur" data-sb-field-path={fieldPath}>
+    <div class="flex items-center justify-between w-full gap-6 px-4 py-3 mx-auto max-w-7xl sm:px-6">
         {
             logo.src ? (
                 <a class="flex items-center" href="/">
                     <ResponsiveImage _id={logo._id} src={logo.src} width={logo.dimensions?.width} height={logo.dimensions?.height} alt={logo.alt} />
                 </a>
             ) : (
-                <a class="text-xl font-bold sm:text-2xl" href="/" data-sb-field-path=".title">
-                    {title}
+                <a class="flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 transition hover:text-primary sm:text-2xl" href="/" data-sb-field-path=".title">
+                    <span class="text-primary">⚡</span>
+                    <span>{wordmark}</span>
                 </a>
             )
         }
         {
             navLinks && navLinks.length > 0 && (
                 <>
-                    <ul class="hidden lg:flex lg:flex-wrap lg:items-center lg:gap-6" data-sb-field-path=".navLinks">
+                    <ul class="hidden items-center gap-1 rounded-full border border-slate-200/80 bg-white/60 px-2 py-1 text-sm font-medium text-slate-700 shadow-sm lg:flex" data-sb-field-path=".navLinks">
                         {navLinks.map((item, index) => (
                             <li>
                                 <Action
                                     action={item}
-                                    class:list={[item._type === 'actionLink' ? 'no-underline hover:underline' : 'px-4 py-3 h-auto min-h-0']}
+                                    class:list={[
+                                        item._type === 'actionLink'
+                                            ? 'px-4 py-2 text-sm font-medium text-slate-700 transition hover:text-primary'
+                                            : 'btn-sm rounded-full px-6 font-semibold shadow-lg shadow-primary/20'
+                                    ]}
                                     data-sb-field-path={`.${index}`}
                                 />
                             </li>
@@ -39,21 +45,23 @@ const { title, logo, navLinks, 'data-sb-field-path': fieldPath } = Astro.props;
                     </ul>
                     <div class="relative lg:hidden">
                         <button
-                            class="inline-flex justify-center items-center w-10 h-10 relative z-2 nav-toggle"
+                            class="relative z-[2] inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200/80 bg-white/80 shadow-sm backdrop-blur nav-toggle"
                             aria-label="Open Menu"
                             aria-expanded="false"
                             aria-controls="nav-panel"
                         >
                             <span class="nav-toggle-icon" />
                         </button>
-                        <div id="nav-panel" class="nav-panel absolute rounded-box -top-2 -right-2 z-1 shadow-xl bg-base-100 border border-base-200/70">
-                            <ul class="flex flex-col px-4 pb-6 pt-14" data-sb-field-path=".navLinks">
+                        <div id="nav-panel" class="nav-panel absolute -right-2 -top-3 z-[1] w-[min(20rem,calc(100vw-1.5rem))] overflow-hidden rounded-3xl border border-slate-200/80 bg-white/95 shadow-2xl backdrop-blur">
+                            <ul class="flex flex-col gap-1 px-4 pb-5 pt-16 text-base" data-sb-field-path=".navLinks">
                                 {navLinks.map((item, index) => (
                                     <li>
                                         <Action
                                             action={item}
                                             class:list={[
-                                                item._type === 'actionLink' ? 'block py-2 no-underline hover:underline' : 'w-full px-4 py-3.5 h-auto min-h-0'
+                                                item._type === 'actionLink'
+                                                    ? 'block rounded-full px-4 py-2.5 text-left text-slate-700 transition hover:bg-slate-100'
+                                                    : 'w-full rounded-full px-5 py-3 font-semibold shadow-lg shadow-primary/20'
                                             ]}
                                             data-sb-field-path={`.${index}`}
                                         />
@@ -71,8 +79,7 @@ const { title, logo, navLinks, 'data-sb-field-path': fieldPath } = Astro.props;
 <style>
     @reference "../styles/globals.css";
     .nav-panel {
-        @apply max-w-72 opacity-0 scale-90 origin-top-right invisible;
-        width: calc(100vw - 1rem);
+        @apply origin-top-right opacity-0 scale-90 invisible;
         transition:
             transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
             opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1),
@@ -81,10 +88,6 @@ const { title, logo, navLinks, 'data-sb-field-path': fieldPath } = Astro.props;
     .nav-panel.is-visible {
         @apply scale-100 opacity-100 visible;
         transition: 0.25s;
-    }
-    .nav-panel li + li:has(.btn),
-    .nav-panel li:has(.btn) + li {
-        @apply mt-4;
     }
     .nav-toggle-icon {
         @apply block relative bg-current rounded transition;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,44 @@ interface Props {
 
 const { addTitleSuffix, description, image } = Astro.props;
 
-const configData: SiteConfig = (await fetchData()) || {};
+const fallbackSiteConfig: SiteConfig = {
+    titleSuffix: 'AI Forward',
+    header: {
+        title: '⚡ AI Forward',
+        navLinks: [
+            { _type: 'actionLink', label: 'The Challenge', url: '#challenge' },
+            { _type: 'actionLink', label: 'Our Approach', url: '#approach' },
+            { _type: 'actionLink', label: 'Solutions', url: '#solutions' },
+            { _type: 'actionLink', label: 'Leadership', url: '#leadership' },
+            {
+                _type: 'actionButton',
+                label: 'Schedule Strategic Call',
+                url: '#consultation',
+                theme: 'primary'
+            }
+        ]
+    },
+    footer: {}
+};
+
+let cmsConfig: SiteConfig | undefined;
+try {
+    cmsConfig = await fetchData();
+} catch (error) {
+    cmsConfig = undefined;
+}
+
+const configData: SiteConfig = {
+    ...fallbackSiteConfig,
+    ...cmsConfig,
+    header: {
+        ...cmsConfig?.header,
+        ...fallbackSiteConfig.header,
+        logo: cmsConfig?.header?.logo ?? fallbackSiteConfig.header?.logo
+    },
+    footer: fallbackSiteConfig.footer
+};
+
 const titleSuffix = configData.titleSuffix && addTitleSuffix !== false ? configData.titleSuffix : undefined;
 const title = [Astro.props.title, titleSuffix].filter(Boolean).join(' | ');
 const resolvedImage = image?.src ? { src: new URL(image.src, Astro.site).toString() } : undefined;
@@ -48,7 +85,10 @@ function formatCanonicalURL(url: string | URL) {
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap"
+            rel="stylesheet"
+        />
 
         <!-- Low Priority Global Metadata -->
         {configData.favicon?.src && <link rel="icon" type="image/svg+xml" href={configData.favicon.src} />}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -10,13 +10,12 @@ import { fetchData, getPageById } from '@data/page';
 
 export async function getStaticPaths() {
     const data = await fetchData();
-    return data.map((page: Page) => {
-        const slug = page.slug.current === '/' ? undefined : page.slug.current;
-        return {
-            params: { slug },
+    return data
+        .filter((page: Page) => page.slug.current && page.slug.current !== '/')
+        .map((page: Page) => ({
+            params: { slug: page.slug.current },
             props: { id: page._id }
-        };
-    });
+        }));
 }
 
 const { id } = Astro.props;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,354 @@
+---
+import Layout from '@layouts/Layout.astro';
+
+const metrics = [
+    {
+        label: 'Time to measurable ROI',
+        value: '90 Days',
+        description: 'From executive alignment to deployed initiatives.'
+    },
+    {
+        label: 'Average first-year return',
+        value: '480%',
+        description: 'Captured through prioritized AI investments.'
+    },
+    {
+        label: 'Average value created',
+        value: '$4.2M',
+        description: 'New revenue, cost savings, and productivity unlocked.'
+    }
+];
+
+const costOfInaction = [
+    {
+        title: 'Market Share Erosion',
+        description:
+            'Competitors using AI are capturing customers faster, serving them better, and pricing more competitively.'
+    },
+    {
+        title: 'Operational Inefficiency',
+        description: 'Your talent is trapped in routine tasks while AI-powered teams focus on strategic growth initiatives.'
+    },
+    {
+        title: 'Decision-Making Delays',
+        description: "While you analyze yesterday's data, AI-enabled leaders are predicting and responding to tomorrow's opportunities."
+    }
+];
+
+const strategicAdvantage = [
+    {
+        title: 'Market Leadership Position',
+        description: 'Accelerate growth with intelligence that anticipates market shifts and customer needs before they emerge.'
+    },
+    {
+        title: 'Operational Excellence',
+        description: 'Transform your team into strategic thinkers while AI handles operational complexity and routine decisions.'
+    },
+    {
+        title: 'Sustainable Competitive Advantage',
+        description: 'Build AI capabilities that compound over time, creating barriers that competitors struggle to overcome.'
+    }
+];
+
+const frameworkSteps = [
+    {
+        number: '01',
+        title: 'Strategic Assessment',
+        description:
+            'Comprehensive analysis of your business model, competitive landscape, and growth objectives to pinpoint the highest-impact AI opportunities.',
+        deliverables: ['Business Process Deep-Dive', 'Competitive Intelligence Report', 'ROI Opportunity Matrix']
+    },
+    {
+        number: '02',
+        title: 'Custom Strategy Blueprint',
+        description:
+            'A prioritized roadmap that clarifies how AI will drive outcomes across your organization, with accountability built in.',
+        deliverables: ['90-Day Implementation Roadmap', 'Technology Architecture Plan', 'Financial Impact Projections']
+    },
+    {
+        number: '03',
+        title: 'Guided Execution',
+        description:
+            'Hands-on partnership with your team to ensure flawless delivery, change management, and continuous optimization.',
+        deliverables: ['Executive Partnership & Support', 'Team Training & Change Management', 'Continuous Performance Optimization']
+    }
+];
+
+const solutions = [
+    {
+        title: 'Revenue Acceleration',
+        description:
+            'Deploy AI-powered market intelligence and customer insights to identify new revenue streams and optimize pricing strategies.',
+        impacts: ['25-40% faster time to market', '15-30% improvement in lifetime value', '20-35% increase in cross-sells']
+    },
+    {
+        title: 'Operational Excellence',
+        description: 'Transform operations with intelligent automation that reduces costs while improving quality and customer experience.',
+        impacts: ['30-50% reduction in cycle times', '40-60% decrease in errors', '20-35% better resource utilization']
+    },
+    {
+        title: 'Strategic Intelligence',
+        description: 'Gain competitive advantage with AI-driven analytics that predict market trends and optimize decision-making.',
+        impacts: ['60-80% better forecast accuracy', '3-6 months faster response to market shifts', '25-45% smarter capital allocation']
+    }
+];
+
+const leaders = [
+    {
+        name: 'Shake Dewan',
+        role: 'Chief Executive Officer',
+        background: 'Former Deloitte Principal and Chief AI Officer guiding enterprise transformations.'
+    },
+    {
+        name: 'Thais Felipelli',
+        role: 'Head of AI Strategy',
+        background: 'Co-Founder of Evino and MIT Sloan MBA focused on outcome-driven innovation.'
+    },
+    {
+        name: 'Alice Wang',
+        role: 'Marketing Director',
+        background: 'Zen Media alum leading go-to-market acceleration and category positioning.'
+    },
+    {
+        name: 'Paul Marz',
+        role: 'Operations Partner',
+        background: 'Former Director of Operations at Disney translating strategy into disciplined execution.'
+    },
+    {
+        name: 'Kevin Lett',
+        role: 'Business Strategy Lead',
+        background: 'Director of Assets at VAALCO Energy with deep expertise in scaling operational excellence.'
+    }
+];
+
+const partnerLogos = ['Deloitte', 'Disney', 'VMWare', 'MIT', 'Zen Media', 'Evino'];
+---
+
+<Layout
+    title="AI Forward | Strategic AI Consulting"
+    description="Strategic AI consulting for executive leaders who demand results. Partner with AI Forward to capture measurable value within 90 days."
+>
+    <main class="bg-base-100 text-base-content">
+        <section id="hero" class="relative isolate overflow-hidden bg-gradient-to-br from-white via-slate-50 to-slate-100 pb-24 pt-28 sm:pb-32">
+            <div class="absolute inset-x-0 -top-32 -z-10 flex justify-center opacity-50">
+                <div class="h-72 w-[28rem] rounded-full bg-primary/20 blur-3xl" />
+            </div>
+            <div class="mx-auto grid max-w-7xl items-center gap-16 px-4 sm:px-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+                <div>
+                    <p class="text-sm font-semibold uppercase tracking-[0.32em] text-primary/80">Trusted by Fortune 500 Leadership Teams</p>
+                    <h1 class="mt-6 max-w-2xl text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl lg:text-6xl">
+                        Your Competition Is Already Using AI to Win
+                    </h1>
+                    <p class="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600">
+                        While you evaluate options, forward-thinking leaders are already capturing market share, reducing costs by 40%, and
+                        accelerating growth with strategic AI implementation.
+                    </p>
+                    <div class="mt-10 flex flex-wrap items-center gap-4">
+                        <a class="btn btn-primary rounded-full px-8 py-3 text-sm font-semibold tracking-wide shadow-lg shadow-primary/25" href="#consultation">
+                            Get Your Strategic Roadmap
+                        </a>
+                        <a class="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary hover:text-primary" href="#approach">
+                            <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                ▶
+                            </span>
+                            Watch Our Approach
+                        </a>
+                    </div>
+                    <div class="mt-14 grid gap-6 sm:grid-cols-3">
+                        {metrics.map((metric) => (
+                            <div class="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-md shadow-primary/5 backdrop-blur">
+                                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">{metric.label}</p>
+                                <p class="mt-4 text-3xl font-semibold text-slate-900">{metric.value}</p>
+                                <p class="mt-3 text-sm text-slate-600">{metric.description}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                <div class="relative">
+                    <div class="absolute inset-0 -z-10 rounded-3xl bg-gradient-to-br from-primary/10 via-white to-primary/5 blur-2xl" />
+                    <div class="relative overflow-hidden rounded-[2rem] border border-slate-200/70 bg-white/90 p-10 shadow-2xl shadow-primary/10 backdrop-blur">
+                        <div class="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+                            Boardroom Briefing
+                        </div>
+                        <h2 class="mt-6 text-2xl font-semibold text-slate-900">AI decisions demand executive precision</h2>
+                        <p class="mt-4 text-base leading-relaxed text-slate-600">
+                            Navigating hype, risk, and complexity is the mandate. We translate AI into strategic advantage with a leadership-first approach that aligns every initiative to measurable value.
+                        </p>
+                        <div class="mt-8 space-y-5">
+                            <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-5">
+                                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Our Approach</p>
+                                <p class="mt-2 text-base text-slate-700">
+                                    Strategy before tooling. We partner with your executives to identify, prioritize, and operationalize AI use cases that move the enterprise needle.
+                                </p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-200/80 bg-white/70 p-5">
+                                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Schedule Strategic Call</p>
+                                <p class="mt-2 text-base text-slate-700">
+                                    Align stakeholders in a complimentary 45-minute session. Expect a clear-eyed view of your AI readiness and the roadmap to accelerate advantage.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="mx-auto mt-20 max-w-7xl px-4 sm:px-6">
+                <p class="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Our leadership team has delivered results at</p>
+                <div class="mt-6 flex flex-wrap items-center gap-3">
+                    {partnerLogos.map((logo) => (
+                        <span class="rounded-full border border-slate-200 bg-white px-5 py-2 text-sm font-medium text-slate-600 shadow-sm">
+                            {logo}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        </section>
+
+        <section id="challenge" class="bg-white py-24 sm:py-28">
+            <div class="mx-auto max-w-7xl px-4 sm:px-6">
+                <div class="grid gap-14 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:items-start">
+                    <div>
+                        <p class="text-sm font-semibold uppercase tracking-[0.32em] text-primary/80">The Strategic Challenge</p>
+                        <h2 class="mt-4 max-w-2xl text-4xl font-semibold text-slate-900 sm:text-5xl">
+                            Every leader knows AI is transformative—few have the clarity to execute without risking the enterprise.
+                        </h2>
+                        <p class="mt-6 max-w-3xl text-lg leading-relaxed text-slate-600">
+                            You see competitors gaining ground, but the noise, hype, and fear of missteps can stall even the most decisive teams. The cost of getting it wrong is enormous. The cost of waiting is even higher.
+                        </p>
+                        <p class="mt-4 max-w-3xl text-lg leading-relaxed text-slate-600">
+                            The question is not whether to adopt AI—it is how quickly you can do it strategically. We guide executive teams through that decision with rigor, transparency, and measurable outcomes.
+                        </p>
+                        <a class="mt-10 inline-flex items-center gap-3 text-sm font-semibold text-primary transition hover:translate-x-1" href="#consultation">
+                            Begin Your Strategic Assessment
+                            <span aria-hidden="true">→</span>
+                        </a>
+                    </div>
+                    <div class="space-y-6">
+                        <div class="rounded-[2rem] border border-slate-200/80 bg-slate-50/80 p-8 shadow-sm">
+                            <h3 class="text-lg font-semibold text-slate-900">The Cost of Inaction</h3>
+                            <div class="mt-6 space-y-5">
+                                {costOfInaction.map((item) => (
+                                    <div>
+                                        <p class="font-semibold text-slate-800">{item.title}</p>
+                                        <p class="mt-1 text-sm text-slate-600">{item.description}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <div class="rounded-[2rem] border border-primary/30 bg-primary/5 p-8 shadow-sm">
+                            <h3 class="text-lg font-semibold text-slate-900">The Strategic Advantage</h3>
+                            <div class="mt-6 space-y-5">
+                                {strategicAdvantage.map((item) => (
+                                    <div>
+                                        <p class="font-semibold text-slate-800">{item.title}</p>
+                                        <p class="mt-1 text-sm text-slate-600">{item.description}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="approach" class="bg-slate-50 py-24 sm:py-28">
+            <div class="mx-auto max-w-7xl px-4 sm:px-6">
+                <p class="text-sm font-semibold uppercase tracking-[0.32em] text-primary/80">Our Approach</p>
+                <div class="mt-4 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                    <h2 class="max-w-3xl text-4xl font-semibold text-slate-900 sm:text-5xl">Our Proven Strategic Framework</h2>
+                    <p class="max-w-xl text-base text-slate-600">
+                        We distilled decades of experience with Fortune 500 enterprises into a clear, executive-ready process. Expect momentum within 90 days and the clarity to scale responsibly.
+                    </p>
+                </div>
+                <div class="mt-16 grid gap-8 lg:grid-cols-3">
+                    {frameworkSteps.map((step) => (
+                        <div class="relative flex h-full flex-col rounded-[2rem] border border-slate-200/80 bg-white p-8 shadow-lg shadow-primary/5">
+                            <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">{step.number}</span>
+                            <h3 class="mt-6 text-2xl font-semibold text-slate-900">{step.title}</h3>
+                            <p class="mt-4 flex-1 text-base leading-relaxed text-slate-600">{step.description}</p>
+                            <ul class="mt-6 space-y-3 text-sm text-slate-600">
+                                {step.deliverables.map((item) => (
+                                    <li class="flex items-start gap-3">
+                                        <span class="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs text-primary">✓</span>
+                                        <span>{item}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+
+        <section id="solutions" class="bg-white py-24 sm:py-28">
+            <div class="mx-auto max-w-7xl px-4 sm:px-6">
+                <p class="text-sm font-semibold uppercase tracking-[0.32em] text-primary/80">Strategic AI Solutions</p>
+                <div class="mt-4 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                    <h2 class="max-w-3xl text-4xl font-semibold text-slate-900 sm:text-5xl">Executive-ready programs engineered for measurable impact.</h2>
+                    <p class="max-w-xl text-base text-slate-600">
+                        Each engagement is bespoke, but the outcomes are consistent: accelerated revenue, disciplined operations, and intelligence that compounds over time.
+                    </p>
+                </div>
+                <div class="mt-16 grid gap-8 lg:grid-cols-3">
+                    {solutions.map((solution) => (
+                        <div class="flex h-full flex-col rounded-[2rem] border border-slate-200/70 bg-slate-50/60 p-8 shadow-sm">
+                            <h3 class="text-2xl font-semibold text-slate-900">{solution.title}</h3>
+                            <p class="mt-4 flex-1 text-base text-slate-600">{solution.description}</p>
+                            <div class="mt-6 space-y-3 text-sm text-slate-600">
+                                {solution.impacts.map((impact) => (
+                                    <div class="flex items-start gap-3">
+                                        <span class="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs text-primary">↑</span>
+                                        <span>{impact}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+
+        <section id="leadership" class="bg-slate-50 py-24 sm:py-28">
+            <div class="mx-auto max-w-7xl px-4 sm:px-6">
+                <p class="text-sm font-semibold uppercase tracking-[0.32em] text-primary/80">Leadership</p>
+                <div class="mt-4 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                    <h2 class="max-w-3xl text-4xl font-semibold text-slate-900 sm:text-5xl">Executive Leadership Team</h2>
+                    <p class="max-w-xl text-base text-slate-600">
+                        Decades of combined experience across consulting, operations, marketing, and innovation. We sit shoulder-to-shoulder with your leadership team to deliver results.
+                    </p>
+                </div>
+                <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                    {leaders.map((leader) => (
+                        <div class="flex h-full flex-col rounded-[2rem] border border-slate-200/80 bg-white p-8 shadow-lg shadow-primary/5">
+                            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary/70">{leader.role}</p>
+                            <h3 class="mt-4 text-xl font-semibold text-slate-900">{leader.name}</h3>
+                            <p class="mt-3 text-sm text-slate-600">{leader.background}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+
+        <section id="consultation" class="relative isolate overflow-hidden bg-gradient-to-br from-primary via-primary/90 to-slate-900 py-24 text-white">
+            <div class="absolute inset-x-0 -top-32 -z-10 flex justify-center opacity-40">
+                <div class="h-80 w-[28rem] rounded-full bg-white/20 blur-3xl" />
+            </div>
+            <div class="mx-auto max-w-5xl px-4 text-center sm:px-6">
+                <p class="text-sm font-semibold uppercase tracking-[0.32em] text-white/70">Your AI Strategy Starts Here</p>
+                <h2 class="mt-6 text-4xl font-semibold leading-tight sm:text-5xl">Schedule a Strategic Consultation</h2>
+                <p class="mt-6 text-lg leading-relaxed text-white/80">
+                    Meet with our executive team for a complimentary 45-minute assessment. You will leave with a clear diagnosis of your AI readiness, the highest-value opportunities, and a tailored roadmap for execution.
+                </p>
+                <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
+                    <a class="btn btn-primary border-none bg-white text-primary hover:bg-white/90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-primary" href="mailto:contact@aiforward.ca">
+                        Reserve Your Consultation
+                    </a>
+                    <a class="inline-flex items-center gap-2 text-sm font-semibold text-white/80 transition hover:text-white" href="tel:+14379614590">
+                        Or call (437) 961-4590
+                        <span aria-hidden="true">→</span>
+                    </a>
+                </div>
+                <p class="mt-6 text-sm font-medium uppercase tracking-[0.3em] text-white/60">Complimentary • 45 Minutes • No Obligation</p>
+            </div>
+        </section>
+    </main>
+</Layout>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,30 +3,57 @@
 
 @plugin "daisyui/theme" {
     name: 'dark';
-    --color-primary: #ffae9c;
-    --color-primary-content: #171227;
-    --color-secondary: #fff2d7;
-    --color-secondary-content: #171227;
-    --color-accent: #e3f1ff;
-    --color-accent-content: #171227;
-    --color-neutral: #2e293c;
-    --color-neutral-content: #ffffff;
-    --color-base-100: #171227;
-    --color-base-200: #2e293c;
-    --color-base-content: #ffffff;
+    --color-primary: #60a5fa;
+    --color-primary-content: #0b1220;
+    --color-secondary: #1f2937;
+    --color-secondary-content: #e2e8f0;
+    --color-accent: #1e3a8a;
+    --color-accent-content: #e0e7ff;
+    --color-neutral: #0b1220;
+    --color-neutral-content: #f8fafc;
+    --color-base-100: #0b1220;
+    --color-base-200: #111827;
+    --color-base-content: #f8fafc;
 }
 
 @plugin "daisyui/theme" {
     name: 'light';
-    --color-primary: #ffae9c;
-    --color-primary-content: #171227;
-    --color-secondary: #fff2d7;
-    --color-secondary-content: #171227;
-    --color-accent: #e3f1ff;
-    --color-accent-content: #171227;
-    --color-neutral: #171227;
-    --color-neutral-content: #ffffff;
-    --color-base-100: #ffffff;
-    --color-base-200: #d7d8e4;
-    --color-base-content: #171227;
+    --color-primary: #2563eb;
+    --color-primary-content: #f8fafc;
+    --color-secondary: #e2e8f0;
+    --color-secondary-content: #0f172a;
+    --color-accent: #c7d2fe;
+    --color-accent-content: #1e1b4b;
+    --color-neutral: #0f172a;
+    --color-neutral-content: #f8fafc;
+    --color-base-100: #f8fafc;
+    --color-base-200: #e2e8f0;
+    --color-base-content: #0f172a;
+}
+
+@layer base {
+    :root {
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: var(--color-base-content);
+        background-color: var(--color-base-100);
+    }
+
+    body {
+        @apply bg-base-100 text-base-content antialiased;
+        font-feature-settings: 'liga' 1, 'kern' 1;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-family: 'Playfair Display', 'Iowan Old Style', 'Sitka Text', Palatino, 'Book Antiqua', serif;
+        @apply text-slate-900;
+    }
+
+    section[id] {
+        scroll-margin-top: 5.5rem;
+    }
 }


### PR DESCRIPTION
## Summary
- create a new AI Forward home page with strategic copy, hero metrics, solutions, leadership, and consultation CTA sections
- refresh the layout, navigation, and footer with brand-specific defaults and light, executive styling
- retheme global styles and interactions for a bright consulting aesthetic

## Testing
- npm run build *(fails: astro CLI missing because packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd10b6a604832daad8612c5866956a